### PR TITLE
Fix ft_strspn and ft_strcspn name mismatch in libft

### DIFF
--- a/libft/ft_strcspn.c
+++ b/libft/ft_strcspn.c
@@ -6,17 +6,17 @@
 /*   By: yhadhadi <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/21 22:07:49 by yhadhadi          #+#    #+#             */
-/*   Updated: 2024/08/21 22:10:22 by yhadhadi         ###   ########.fr       */
+/*   Updated: 2024/08/22 04:45:12 by yhadhadi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-size_t	ft_strspn(const char *str, const char *accept)
+size_t	ft_strcspn(const char *str, const char *reject)
 {
 	const char	*p_str = str;
 
-	while (*p_str && ft_strchr(accept, *p_str))
+	while (*p_str && !ft_strchr(reject, *p_str))
 		++p_str;
 	return (p_str - str);
 }

--- a/libft/ft_strspn.c
+++ b/libft/ft_strspn.c
@@ -6,17 +6,17 @@
 /*   By: yhadhadi <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/21 22:07:48 by yhadhadi          #+#    #+#             */
-/*   Updated: 2024/08/21 22:08:26 by yhadhadi         ###   ########.fr       */
+/*   Updated: 2024/08/22 04:44:13 by yhadhadi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-size_t	ft_strcspn(const char *str, const char *reject)
+size_t	ft_strspn(const char *str, const char *accept)
 {
 	const char	*p_str = str;
 
-	while (*p_str && !ft_strchr(reject, *p_str))
+	while (*p_str && ft_strchr(accept, *p_str))
 		++p_str;
 	return (p_str - str);
 }


### PR DESCRIPTION
Merge commit 'aeafcfa9d509a666b4688338141cd2069c0c1f0d' from libft subtree tracking branch as 'libft'.